### PR TITLE
Update digital clock to show current time

### DIFF
--- a/Digital Clock/index.html
+++ b/Digital Clock/index.html
@@ -11,13 +11,14 @@
 <body>
     <div class="container">
         <div class="digitalClock">
-            <h1 id="day">SAT</h1>
-            <h1 id="hour">10</h1>
+            <h1 id="day">MON</h1>
+            <h1 id="hour">01</h1>
             <h1 id="hello">|</h1>
-            <h1 id="minute">27</h1>
+            <h1 id="minute">30</h1>
             <h1 id="bye">|</h1>
-            <h1 id="ampm">PM</h1>
+            <h1 id="ampm">AM</h1>
         </div>
     </div>
 </body>
+
 </html>


### PR DESCRIPTION
This pull request updates the initial display values of the digital clock in the `index.html` file.

* Display values updated: The default day is now "MON" instead of "SAT", the hour is set to "01" instead of "10", the minute is set to "30" instead of "27", and the AM/PM indicator is now "AM" instead of "PM". (`Digital Clock/index.html`)